### PR TITLE
Corrected Production URL for Process Shipment

### DIFF
--- a/lib/fex/service_factory.rb
+++ b/lib/fex/service_factory.rb
@@ -5,7 +5,7 @@ require "fex/ship_response"
 module Fex
   class ServiceFactory
 
-    PRODUCTION_ENDPOINT = "https://ws.fedex.com:443/web-services/rate"
+    PRODUCTION_ENDPOINT = "https://ws.fedex.com:443/web-services"
 
     attr_reader :name, :mode, :client_options, :version, :defaults, :wsdl, :response
 


### PR DESCRIPTION
Corrected the `PRODUCTION_ENDPOINT` as it was preventing processing of shipment in production mode.
